### PR TITLE
Fix minor issues in npm publish.

### DIFF
--- a/.github/workflows/npm-publish-staging.yml
+++ b/.github/workflows/npm-publish-staging.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Copy Proto Files
         run: |
           mkdir -p javascript_rpc/edgepi_rpc_protos
-          cp *.proto javascript_rpc/edgepi_rpc_protos/
+          cp *.proto javascript_rpc/edgepi_rpc_protos
 
       - name: Install and Test
         run: |

--- a/.github/workflows/npm-publish-staging.yml
+++ b/.github/workflows/npm-publish-staging.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           mkdir -p javascript_rpc/edgepi_rpc_protos
           cp *.proto javascript_rpc/edgepi_rpc_protos
+          cp LICENSE javascript_rpc
 
       - name: Install and Test
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Copy Proto Files
         run: |
           mkdir -p javascript_rpc/edgepi_rpc_protos
-          cp *.proto javascript_rpc/edgepi_rpc_protos/
+          cp *.proto javascript_rpc/edgepi_rpc_protos
 
       - name: Install and Test
         run: |
@@ -32,6 +32,7 @@ jobs:
           if npm view @edgepi-cloud/edgepi-rpc-protobuf@beta versions --json | grep -q $VERSION
           then
             npm dist-tag add @edgepi-cloud/edgepi-rpc-protobuf@$VERSION latest
+            npm dist-tag rm @edgepi-cloud/edgepi-rpc-protobuf beta
           else
             npm publish --access public
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           mkdir -p javascript_rpc/edgepi_rpc_protos
           cp *.proto javascript_rpc/edgepi_rpc_protos
+          cp LICENSE javascript_rpc
 
       - name: Install and Test
         run: |

--- a/javascript_rpc/package.json
+++ b/javascript_rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgepi-cloud/edgepi-rpc-protobuf",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "EdgePi RPC Protobuf Module",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/EdgePi-Cloud/edgepi-rpc-protobuf/tree/main/javascript_rpc",
   "files": [
-    "./*.proto"
+    "edgepi_rpc_protos"
   ],
   "devDependencies": {
     "protobufjs": "^6.11.2",

--- a/python_rpc/setup.cfg
+++ b/python_rpc/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = edgepi-rpc-protobuf
-version = 1.0.22
+version = 1.0.23
 author = Isaac James
 author_email = ijames@osensa.com
 description = Protobuf generated code for EdgePi RPC


### PR DESCRIPTION
Updated the files field in package.json to check *.proto files under the newly created subdirectory.

Copy the LICENSE into the Javascript directory in the publish workflows.

Added a step in the npm publish workflow to remove the beta tag after adding the latest tag (so that there aren't 2 tags for the latest version).